### PR TITLE
feat: add application skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual environments
+.env/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# Pet-Project_test1
+# Pet-Project Test 1
+
+This repository contains a Python application skeleton designed for future
+extension with machine learning, geometric computations, 3D rendering and
+integration with external APIs such as OpenAI and Meshy.
+
+## Structure
+
+```
+pet_project/
+├── api/           # clients for OpenAI, Meshy and similar services
+├── geometry/      # geometric utilities and mesh operations
+├── ml/            # machine learning models and helpers
+├── render/        # 3D rendering engines and helpers
+└── main.py        # application entry point
+```
+
+## Requirements
+
+Dependencies for potential future features are listed in
+[`requirements.txt`](requirements.txt). These libraries are not installed by
+default.

--- a/pet_project/__init__.py
+++ b/pet_project/__init__.py
@@ -1,0 +1,8 @@
+"""Main package for the pet project skeleton."""
+
+__all__ = [
+    'api',
+    'ml',
+    'geometry',
+    'render',
+]

--- a/pet_project/api/__init__.py
+++ b/pet_project/api/__init__.py
@@ -1,0 +1,6 @@
+"""API clients for external services like OpenAI and Meshy."""
+
+from .openai_client import OpenAIClient
+from .meshy_client import MeshyClient
+
+__all__ = ["OpenAIClient", "MeshyClient"]

--- a/pet_project/api/meshy_client.py
+++ b/pet_project/api/meshy_client.py
@@ -1,0 +1,18 @@
+"""Client utilities for interacting with the Meshy API."""
+
+from __future__ import annotations
+from typing import Any
+
+
+class MeshyClient:
+    """Placeholder for Meshy API interactions."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def generate_mesh(self, data: Any) -> Any:
+        """Generate or process a mesh using Meshy API.
+
+        The implementation should call Meshy's API once integrated.
+        """
+        raise NotImplementedError("Meshy integration not yet implemented")

--- a/pet_project/api/openai_client.py
+++ b/pet_project/api/openai_client.py
@@ -1,0 +1,19 @@
+"""Client utilities for interacting with the OpenAI API."""
+
+from __future__ import annotations
+from typing import Any
+
+
+class OpenAIClient:
+    """Placeholder for OpenAI API interactions."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def generate_text(self, prompt: str, **kwargs: Any) -> str:
+        """Generate text from a prompt using the OpenAI API.
+
+        This method is a stub and should be implemented with actual OpenAI
+        API calls.
+        """
+        raise NotImplementedError("OpenAI integration not yet implemented")

--- a/pet_project/geometry/__init__.py
+++ b/pet_project/geometry/__init__.py
@@ -1,0 +1,5 @@
+"""Geometric operations for meshes and shapes."""
+
+from .operations import calculate_volume
+
+__all__ = ["calculate_volume"]

--- a/pet_project/geometry/operations.py
+++ b/pet_project/geometry/operations.py
@@ -1,0 +1,13 @@
+"""Placeholder geometric operations."""
+
+from __future__ import annotations
+from typing import Any
+
+
+def calculate_volume(mesh: Any) -> float:
+    """Calculate the volume of a mesh.
+
+    The actual implementation should utilize a geometry library such as
+    ``trimesh`` or ``pyvista``.
+    """
+    raise NotImplementedError

--- a/pet_project/main.py
+++ b/pet_project/main.py
@@ -1,0 +1,13 @@
+"""Entry point for the application."""
+
+from __future__ import annotations
+
+
+def run() -> None:
+    """Run the core application logic."""
+    # This function will be expanded as features are implemented.
+    print("Application skeleton running")
+
+
+if __name__ == "__main__":
+    run()

--- a/pet_project/ml/__init__.py
+++ b/pet_project/ml/__init__.py
@@ -1,0 +1,5 @@
+"""Machine learning models and utilities."""
+
+from .models import BaseModel
+
+__all__ = ["BaseModel"]

--- a/pet_project/ml/models.py
+++ b/pet_project/ml/models.py
@@ -1,0 +1,16 @@
+"""Base classes for machine learning models."""
+
+from __future__ import annotations
+from typing import Any
+
+
+class BaseModel:
+    """Abstract base class for ML models."""
+
+    def train(self, data: Any) -> None:
+        """Train the model on the provided data."""
+        raise NotImplementedError
+
+    def predict(self, data: Any) -> Any:
+        """Generate predictions for the provided data."""
+        raise NotImplementedError

--- a/pet_project/render/__init__.py
+++ b/pet_project/render/__init__.py
@@ -1,0 +1,5 @@
+"""3D rendering utilities."""
+
+from .renderer import Renderer
+
+__all__ = ["Renderer"]

--- a/pet_project/render/renderer.py
+++ b/pet_project/render/renderer.py
@@ -1,0 +1,16 @@
+"""Placeholder renderer for 3D visualization."""
+
+from __future__ import annotations
+from typing import Any
+
+
+class Renderer:
+    """Stub renderer class."""
+
+    def render(self, scene: Any) -> None:
+        """Render the provided scene.
+
+        The implementation should integrate with a rendering library such as
+        ``pyvista`` or ``trimesh``.
+        """
+        raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+# Core dependencies
+numpy
+scipy
+
+# Machine Learning
+torch
+
+# Geometry and 3D rendering
+trimesh
+pyvista
+
+# API clients
+openai
+meshy


### PR DESCRIPTION
## Summary
- scaffold Python package structure for ML, geometry, rendering, and API integrations
- add placeholders for OpenAI and Meshy clients
- document project layout and dependencies

## Testing
- `python -m py_compile $(find pet_project -name '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68978854fc14832182b5b56f6e4f825c